### PR TITLE
feat: add shared toggle, spinner, and tableSkeleton UIs

### DIFF
--- a/web/src/components/shared/LoadingSpinner.tsx
+++ b/web/src/components/shared/LoadingSpinner.tsx
@@ -22,8 +22,12 @@ export function LoadingSpinner({ className, size = "md" }: LoadingSpinnerProps) 
       strokeLinecap="round"
       strokeLinejoin="round"
       className={cn(`animate-spin text-foreground ${sizeClasses[size]}`, className)}
+      role="status"
+      aria-label="Loading"
     >
       <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+      {/* Fallback for older screen readers */}
+      <span className="sr-only">Loading</span>
     </svg>
   );
 }

--- a/web/src/components/shared/LoadingSpinner.tsx
+++ b/web/src/components/shared/LoadingSpinner.tsx
@@ -6,7 +6,6 @@ interface LoadingSpinnerProps {
 }
 
 export function LoadingSpinner({ className, size = "md" }: LoadingSpinnerProps) {
-  
   const sizeClasses = {
     sm: "h-4 w-4",
     md: "h-6 w-6",
@@ -22,8 +21,7 @@ export function LoadingSpinner({ className, size = "md" }: LoadingSpinnerProps) 
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      // overridden by passing a Tailwind text color into className
-      className={cn(`animate-spin text-slate-800 ${sizeClasses[size]}`, className)}
+      className={cn(`animate-spin text-foreground ${sizeClasses[size]}`, className)}
     >
       <path d="M21 12a9 9 0 1 1-6.219-8.56" />
     </svg>

--- a/web/src/components/shared/LoadingSpinner.tsx
+++ b/web/src/components/shared/LoadingSpinner.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+interface LoadingSpinnerProps {
+  className?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+export function LoadingSpinner({ className, size = "md" }: LoadingSpinnerProps) {
+  
+  const sizeClasses = {
+    sm: "h-4 w-4",
+    md: "h-6 w-6",
+    lg: "h-8 w-8",
+  };
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      // overridden by passing a Tailwind text color into className
+      className={cn(`animate-spin text-slate-800 ${sizeClasses[size]}`, className)}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}

--- a/web/src/components/shared/StatusToggle.tsx
+++ b/web/src/components/shared/StatusToggle.tsx
@@ -1,0 +1,42 @@
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils"; 
+
+interface StatusToggleProps {
+  isActive: boolean;
+  onToggle: (checked: boolean) => void;
+  activeText?: string; 
+  inactiveText?: string;
+  disabled?: boolean;
+  className?: string; // Add the className prop
+}
+
+export function StatusToggle({
+  isActive,
+  onToggle,
+  activeText = "Active",
+  inactiveText = "Inactive",
+  disabled = false,
+  className, 
+}: StatusToggleProps) {
+  return (
+    
+    <div className={cn("flex items-center space-x-3", className)}>
+      <Switch
+        id="status-toggle"
+        checked={isActive}
+        onCheckedChange={onToggle}
+        disabled={disabled}
+      />
+      <Label 
+        htmlFor="status-toggle" 
+        className={cn(
+          "text-sm font-medium transition-colors",
+          isActive ? "text-slate-900" : "text-slate-500"
+        )}
+      >
+        {isActive ? activeText : inactiveText}
+      </Label>
+    </div>
+  );
+}

--- a/web/src/components/shared/StatusToggle.tsx
+++ b/web/src/components/shared/StatusToggle.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useId } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils"; 
@@ -8,7 +11,8 @@ interface StatusToggleProps {
   activeText?: string; 
   inactiveText?: string;
   disabled?: boolean;
-  className?: string; // Add the className prop
+  className?: string;
+  id?: string;
 }
 
 export function StatusToggle({
@@ -17,22 +21,26 @@ export function StatusToggle({
   activeText = "Active",
   inactiveText = "Inactive",
   disabled = false,
-  className, 
+  className,
+  id, 
 }: StatusToggleProps) {
+  // Generates a unique ID automatically if one isn't provided
+  const generatedId = useId();
+  const toggleId = id || `status-toggle-${generatedId}`;
+
   return (
-    
     <div className={cn("flex items-center space-x-3", className)}>
       <Switch
-        id="status-toggle"
+        id={toggleId}
         checked={isActive}
         onCheckedChange={onToggle}
         disabled={disabled}
       />
       <Label 
-        htmlFor="status-toggle" 
+        htmlFor={toggleId} 
         className={cn(
           "text-sm font-medium transition-colors",
-          isActive ? "text-slate-900" : "text-slate-500"
+          isActive ? "text-foreground" : "text-muted-foreground"
         )}
       >
         {isActive ? activeText : inactiveText}

--- a/web/src/components/shared/TableSkeleton.tsx
+++ b/web/src/components/shared/TableSkeleton.tsx
@@ -18,22 +18,19 @@ export function TableSkeleton({
     <div className="w-full space-y-4">
       
       {/* Table Header Placeholder */}
-      <div className="flex items-center space-x-4 border-b pb-4 px-2">
-        {showCheckbox && <Skeleton className="h-4 w-4 rounded bg-slate-200" />}
-        {/* Generates a header block for every width in the array */}
+      <div className="flex items-center space-x-4 border-b border-border pb-4 px-2">
+        {showCheckbox && <Skeleton className="h-4 w-4 rounded" />}
         {columnWidths.map((width, index) => (
-          <Skeleton key={`header-col-${index}`} className={`h-6 ${width} bg-slate-200`} />
+          <Skeleton key={`header-col-${index}`} className={`h-6 ${width}`} />
         ))}
       </div>
       
       {/* Table Rows Placeholder */}
       {Array.from({ length: rowCount }).map((_, rowIndex) => (
-        <div key={`row-${rowIndex}`} className="flex items-center space-x-4 py-3 px-2 border-b border-slate-50 last:border-0">
-          {showCheckbox && <Skeleton className="h-4 w-4 rounded bg-slate-100" />}
-          
-          {/* Generates the cells for this specific row based on the same array */}
+        <div key={`row-${rowIndex}`} className="flex items-center space-x-4 py-3 px-2 border-b border-border last:border-0">
+          {showCheckbox && <Skeleton className="h-4 w-4 rounded" />}
           {columnWidths.map((width, colIndex) => (
-            <Skeleton key={`cell-${rowIndex}-${colIndex}`} className={`h-5 ${width} bg-slate-100`} />
+            <Skeleton key={`cell-${rowIndex}-${colIndex}`} className={`h-5 ${width}`} />
           ))}
         </div>
       ))}

--- a/web/src/components/shared/TableSkeleton.tsx
+++ b/web/src/components/shared/TableSkeleton.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface TableSkeletonProps {
+  // placeholder rows to show (defaults to 5)
+  rowCount?: number; 
+  // An array of Tailwind width classes defining the layout (e.g., ["w-[20%]", "w-[50%]", "w-[30%]"])
+  columnWidths: string[]; 
+  // Whether to include a small checkbox skeleton (defaults to true)
+  showCheckbox?: boolean; 
+}
+
+export function TableSkeleton({ 
+  rowCount = 5, 
+  columnWidths, 
+  showCheckbox = true 
+}: TableSkeletonProps) {
+  return (
+    <div className="w-full space-y-4">
+      
+      {/* Table Header Placeholder */}
+      <div className="flex items-center space-x-4 border-b pb-4 px-2">
+        {showCheckbox && <Skeleton className="h-4 w-4 rounded bg-slate-200" />}
+        {/* Generates a header block for every width in the array */}
+        {columnWidths.map((width, index) => (
+          <Skeleton key={`header-col-${index}`} className={`h-6 ${width} bg-slate-200`} />
+        ))}
+      </div>
+      
+      {/* Table Rows Placeholder */}
+      {Array.from({ length: rowCount }).map((_, rowIndex) => (
+        <div key={`row-${rowIndex}`} className="flex items-center space-x-4 py-3 px-2 border-b border-slate-50 last:border-0">
+          {showCheckbox && <Skeleton className="h-4 w-4 rounded bg-slate-100" />}
+          
+          {/* Generates the cells for this specific row based on the same array */}
+          {columnWidths.map((width, colIndex) => (
+            <Skeleton key={`cell-${rowIndex}-${colIndex}`} className={`h-5 ${width} bg-slate-100`} />
+          ))}
+        </div>
+      ))}
+      
+    </div>
+  );
+}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -24,7 +24,7 @@ function Switch({
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[state=checked]/switch:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[state=unchecked]/switch:translate-x-0 dark:data-unchecked:bg-foreground"
       />
     </SwitchPrimitive.Root>
   )


### PR DESCRIPTION
This PR introduces three foundational, reusable UI components to the `src/components/shared` directory. These components are built to ensure visual consistency and reduce code duplication.

### Components Added:
- **`StatusToggle`**: A reusable active/inactive switch built on top of Shadcn. It defaults to "Active/Inactive" but accepts custom text props for different use cases.
- **`LoadingSpinner`**: A standardized SVG spinner. It includes built-in size variants (`sm`, `md`, `lg`) to keep scaling consistent across the app.
- **`TableSkeleton`**: A fully dynamic loading skeleton for data tables. Instead of a hardcoded shape, it accepts a `columnWidths` array (e.g., `["w-[20%]", "w-[50%]"]`) to instantly generate a placeholder that perfectly matches the target table's Figma design before data fetches.

