### PR TITLE
Feature/receiving an asset mark as returned

### DIFF
--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -213,7 +213,7 @@ export async function sendAssignmentReminderAction(
   }
 
   try {
-    await triggerAssignmentReminders(assignmentIds);
+    await triggerAssignmentReminders(assignmentIds, currentUser.id);
     revalidatePath('/operations/assignments');
     return { success: true };
   } catch (error) {
@@ -244,7 +244,7 @@ export async function requestAssetReturnAction(
   }
 
   try {
-    await triggerReturnRequests(assignmentIds);
+    await triggerReturnRequests(assignmentIds, currentUser.id);
     revalidatePath('/operations/assignments');
     revalidatePath('/assets');
     return { success: true };
@@ -276,7 +276,7 @@ export async function markAssetReceivedAction(
   }
 
   try {
-    await markAssignmentsAsReceived(assignmentIds);
+    await markAssignmentsAsReceived(assignmentIds, currentUser.id);
     revalidatePath('/operations/assignments');
     revalidatePath('/assets');
     return { success: true };

--- a/src/actions/assignments.ts
+++ b/src/actions/assignments.ts
@@ -83,7 +83,7 @@ export async function assignAssetAction(
       if (err instanceof ZodError) {
         return {
           success: false,
-          error: 'Invalid input for assignAssetAction.',
+          error: err.issues[0]?.message || 'Invalid input for assignAssetAction.',
           code: 'VALIDATION_ERROR',
         };
       }
@@ -144,7 +144,7 @@ export async function bulkAssignAssetsAction(
       if (err instanceof ZodError) {
         return {
           success: false,
-          error: 'Invalid input for bulkAssignAssetsAction.',
+          error: err.issues[0]?.message || 'Invalid input for bulkAssignAssetsAction.',
           code: 'VALIDATION_ERROR',
         };
       }

--- a/src/components/features/operations/assignments/asset-assignment-modal.tsx
+++ b/src/components/features/operations/assignments/asset-assignment-modal.tsx
@@ -152,6 +152,17 @@ export function AssetAssignmentModal({
       return;
     }
 
+    if (resolvedAssignmentMode === "user" && expectedReturn) {
+      const selectedDate = new Date(expectedReturn);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      if (selectedDate < today) {
+        tiqriToast.error("Select a valid date");
+        return;
+      }
+    }
+
     setIsSubmitting(true);
 
     const expectedDate = resolvedAssignmentMode === "user" ? expectedReturn || undefined : undefined;

--- a/src/components/features/operations/assignments/asset-assignment-modal.tsx
+++ b/src/components/features/operations/assignments/asset-assignment-modal.tsx
@@ -153,7 +153,8 @@ export function AssetAssignmentModal({
     }
 
     if (resolvedAssignmentMode === "user" && expectedReturn) {
-      const selectedDate = new Date(expectedReturn);
+      const [year, month, day] = expectedReturn.split("-").map(Number);
+      const selectedDate = new Date(year, month - 1, day);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 

--- a/src/components/features/operations/assignments/asset-assignment-modal.tsx
+++ b/src/components/features/operations/assignments/asset-assignment-modal.tsx
@@ -153,7 +153,11 @@ export function AssetAssignmentModal({
     }
 
     if (resolvedAssignmentMode === "user" && expectedReturn) {
-      const selectedDate = new Date(expectedReturn);
+      // Parse YYYY-MM-DD as local date to avoid timezone issues (new Date(str) parses as UTC)
+      const parts = expectedReturn.split("-").map((p) => Number(p));
+      const selectedDate = parts.length === 3
+        ? new Date(parts[0], (parts[1] || 1) - 1, parts[2])
+        : new Date(expectedReturn);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 

--- a/src/components/features/operations/assignments/assignments-dashboard.tsx
+++ b/src/components/features/operations/assignments/assignments-dashboard.tsx
@@ -469,7 +469,7 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
       : columns.filter((col) => !("accessorKey" in col) || col.accessorKey !== "state");
 
     return (
-      <div className="space-y-4">
+      <div className="flex flex-1 flex-col min-h-0 space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="relative w-full max-w-136.25">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
@@ -718,7 +718,7 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
         data={rows}
         onRowClick={handleRowClick}
         initialPageSize={10}
-        className="rounded-lg border-slate-200"
+        className="flex-1 min-h-0 rounded-lg border-slate-200"
         selectionActions={actions}
         selectionLabel={(count) => `${count} Assets Selected`}
         rowSelection={rowSelection}
@@ -737,10 +737,11 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
           </h1>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <ModuleNavigationTabs
             tabs={tabs}
             defaultTab="available-assets"
+            containerClassName="flex flex-col flex-1 min-h-0"
             onTabChange={() => {
               setRowSelection({});
               if (isPanelOpen) {

--- a/src/components/features/operations/assignments/assignments-dashboard.tsx
+++ b/src/components/features/operations/assignments/assignments-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ChevronDown, Search, X } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
@@ -67,6 +67,14 @@ type CategoryFilter = {
   value: string;
 };
 
+type AssignedFilterField = "Status" | "Category";
+
+type AssignedFilter = {
+  field: AssignedFilterField;
+  operator: CategoryFilterOperator;
+  value: string;
+};
+
 interface AssignmentsDashboardProps {
   data: AssignmentsDashboardData;
 }
@@ -76,6 +84,8 @@ const tabs = [
   { id: "assigned-assets", label: "Assigned Assets" },
   { id: "returned-assets", label: "Returned Assets" },
 ];
+
+const ASSIGNED_STATUS_OPTIONS = ["pending approval", "assigned", "overdue", "requested", "returned"];
 
 // --- Helpers ---
 
@@ -105,13 +115,19 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
   const [searchValue, setSearchValue] = useState("");
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
+  // Assigned Assets Filter State
+  const [appliedAssignedFilters, setAppliedAssignedFilters] = useState<AssignedFilter[]>([]);
+  const [assignedDraftField, setAssignedDraftField] = useState<AssignedFilterField>("Status");
+  const [assignedDraftOperator, setAssignedDraftOperator] = useState<CategoryFilterOperator>("is");
+  const [assignedDraftValue, setAssignedDraftValue] = useState("");
+
   // 1. Panel State from URL (following the Registry Pattern)
   const activeAssetId = searchParams.get("id") || "";
   const currentPanel = searchParams.get("panel");
   const isPanelOpen = currentPanel === "record" && activeAssetId !== "";
 
   // 2. Data Mapping
-  const mapRow = (asset: AssignmentsDashboardRow): AssetAssignmentRow => ({
+  const mapRow = useCallback((asset: AssignmentsDashboardRow): AssetAssignmentRow => ({
     assetId: asset.id,
     assetName: asset.name ?? asset.assetTag,
     serialNumber: asset.serialNumber ?? "-",
@@ -133,21 +149,21 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
     assetTag: asset.assetTag,
     state: asset.state,
     assignmentId: asset.assignmentId ?? undefined,
-  });
+  }), []);
 
   const availableRows = useMemo<AssetAssignmentRow[]>(
     () => data.available.map(mapRow),
-    [data.available]
+    [data.available, mapRow]
   );
 
   const assignedRows = useMemo<AssetAssignmentRow[]>(
     () => data.assigned.map(mapRow),
-    [data.assigned]
+    [data.assigned, mapRow]
   );
 
   const returnedRows = useMemo<AssetAssignmentRow[]>(
     () => data.returned.map(mapRow),
-    [data.returned]
+    [data.returned, mapRow]
   );
 
   const assetRows = useMemo(
@@ -166,6 +182,13 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
 
     return [...categories].sort((left, right) => left.localeCompare(right));
   }, [assetRows]);
+
+  const assignedFilterValueOptions = useMemo(() => {
+    if (assignedDraftField === "Status") {
+      return ASSIGNED_STATUS_OPTIONS;
+    }
+    return categoryOptions;
+  }, [assignedDraftField, categoryOptions]);
 
   const searchedAssetRows = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
@@ -204,10 +227,23 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
     [availableRows, filteredAssetRows]
   );
 
-  const filteredAssignedRows = useMemo(
-    () => filteredAssetRows.filter((row) => assignedRows.some((assignedRow) => assignedRow.assetId === row.assetId)),
-    [assignedRows, filteredAssetRows]
-  );
+  const filteredAssignedRows = useMemo(() => {
+    let results = searchedAssetRows.filter((row) => assignedRows.some((assignedRow) => assignedRow.assetId === row.assetId));
+
+    if (appliedAssignedFilters.length === 0) {
+      return results;
+    }
+
+    for (const filter of appliedAssignedFilters) {
+      results = results.filter((row) => {
+        const val = filter.field === "Status" ? row.state : row.category;
+        const matches = val === filter.value;
+        return filter.operator === "is" ? matches : !matches;
+      });
+    }
+
+    return results;
+  }, [assignedRows, searchedAssetRows, appliedAssignedFilters]);
 
   const filteredReturnedRows = useMemo(
     () => filteredAssetRows.filter((row) => returnedRows.some((returnedRow) => returnedRow.assetId === row.assetId)),
@@ -425,7 +461,8 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
   const renderTable = (
     rows: AssetAssignmentRow[],
     actions?: DataTableSelectionAction<AssetAssignmentRow>[],
-    showStatusColumn = false
+    showStatusColumn = false,
+    filterType: "available" | "assigned" | "returned" = "available"
   ) => {
     const tableColumns = showStatusColumn
       ? columns
@@ -477,39 +514,94 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
             </div>
 
             <div className="space-y-3 px-3 py-3">
-              <div className="space-y-2 text-sm text-slate-700">
-                <label className="flex items-center gap-2">
-                  <input
-                    type="radio"
-                    checked={draftOperator === "is"}
-                    onChange={() => setDraftOperator("is")}
-                  />
-                  is
-                </label>
-                <label className="flex items-center gap-2">
-                  <input
-                    type="radio"
-                    checked={draftOperator === "is not"}
-                    onChange={() => setDraftOperator("is not")}
-                  />
-                  is not
-                </label>
-              </div>
+              {filterType === "assigned" ? (
+                <>
+                  <select
+                    value={assignedDraftField}
+                    onChange={(event) => {
+                      const nextField = event.target.value as AssignedFilterField;
+                      setAssignedDraftField(nextField);
+                      const nextOptions = nextField === "Status" ? ASSIGNED_STATUS_OPTIONS : categoryOptions;
+                      setAssignedDraftValue(nextOptions[0] || "");
+                    }}
+                    className="h-8 w-full rounded-lg border border-slate-200 bg-white px-2 text-sm text-slate-700"
+                  >
+                    <option value="Status">Status</option>
+                    <option value="Category">Category</option>
+                  </select>
 
-              <select
-                value={draftCategory}
-                onChange={(event) => setDraftCategory(event.target.value)}
-                className="h-8 w-full rounded-lg border border-slate-200 bg-white px-2 text-sm text-slate-700"
-              >
-                <option value="" disabled>
-                  Select category
-                </option>
-                {categoryOptions.map((categoryOption) => (
-                  <option key={categoryOption} value={categoryOption}>
-                    {categoryOption}
-                  </option>
-                ))}
-              </select>
+                  <div className="space-y-2 text-sm text-slate-700">
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        checked={assignedDraftOperator === "is"}
+                        onChange={() => setAssignedDraftOperator("is")}
+                      />
+                      is
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        checked={assignedDraftOperator === "is not"}
+                        onChange={() => setAssignedDraftOperator("is not")}
+                      />
+                      is not
+                    </label>
+                  </div>
+
+                  <select
+                    value={assignedDraftValue}
+                    onChange={(event) => setAssignedDraftValue(event.target.value)}
+                    className="h-8 w-full rounded-lg border border-slate-200 bg-white px-2 text-sm text-slate-700"
+                  >
+                    <option value="" disabled>
+                      Select {assignedDraftField.toLowerCase()}
+                    </option>
+                    {assignedFilterValueOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </>
+              ) : (
+                <>
+                  <div className="text-sm font-medium text-slate-700 mb-1">Category</div>
+                  <div className="space-y-2 text-sm text-slate-700">
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        checked={draftOperator === "is"}
+                        onChange={() => setDraftOperator("is")}
+                      />
+                      is
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        checked={draftOperator === "is not"}
+                        onChange={() => setDraftOperator("is not")}
+                      />
+                      is not
+                    </label>
+                  </div>
+
+                  <select
+                    value={draftCategory}
+                    onChange={(event) => setDraftCategory(event.target.value)}
+                    className="h-8 w-full rounded-lg border border-slate-200 bg-white px-2 text-sm text-slate-700"
+                  >
+                    <option value="" disabled>
+                      Select category
+                    </option>
+                    {categoryOptions.map((categoryOption) => (
+                      <option key={categoryOption} value={categoryOption}>
+                        {categoryOption}
+                      </option>
+                    ))}
+                  </select>
+                </>
+              )}
             </div>
 
             <div className="flex items-center justify-end gap-2 border-t border-slate-200 px-3 py-2">
@@ -527,11 +619,25 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
                 size="sm"
                 className="h-8 rounded-lg bg-[#0B1D74] px-3 text-sm text-white hover:bg-[#0A175C]"
                 onClick={() => {
-                  if (draftCategory) {
-                    setAppliedCategoryFilter({
-                      operator: draftOperator,
-                      value: draftCategory,
-                    });
+                  if (filterType === "assigned") {
+                    if (assignedDraftValue) {
+                      const nextFilter: AssignedFilter = {
+                        field: assignedDraftField,
+                        operator: assignedDraftOperator,
+                        value: assignedDraftValue,
+                      };
+                      setAppliedAssignedFilters((current) => {
+                        const withoutCurrentField = current.filter(f => f.field !== nextFilter.field);
+                        return [...withoutCurrentField, nextFilter];
+                      });
+                    }
+                  } else {
+                    if (draftCategory) {
+                      setAppliedCategoryFilter({
+                        operator: draftOperator,
+                        value: draftCategory,
+                      });
+                    }
                   }
 
                   setIsFilterPopoverOpen(false);
@@ -544,7 +650,43 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
         </Popover>
       </div>
 
-      {appliedCategoryFilter ? (
+      {filterType === "assigned" ? (
+        appliedAssignedFilters.length > 0 ? (
+          <div className="mt-2 flex items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              {appliedAssignedFilters.map((filter) => (
+                <span key={filter.field} className="inline-flex h-8 items-center gap-2 rounded-lg bg-slate-100 px-3 text-sm text-slate-700">
+                  {`${filter.field} ${filter.operator} ${filter.value}`}
+                  <button
+                    type="button"
+                    className="text-slate-500 hover:text-slate-700"
+                    onClick={() => setAppliedAssignedFilters(current => current.filter(f => f.field !== filter.field))}
+                  >
+                    <X className="size-4" />
+                  </button>
+                </span>
+              ))}
+              <button
+                type="button"
+                className="inline-flex size-8 items-center justify-center rounded-lg text-xl text-slate-600 hover:bg-slate-100"
+                onClick={() => setIsFilterPopoverOpen(true)}
+              >
+                +
+              </button>
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-lg border-slate-200 bg-white px-3 text-sm text-slate-700"
+              onClick={() => setAppliedAssignedFilters([])}
+            >
+              Clear Filters
+            </Button>
+          </div>
+        ) : null
+      ) : appliedCategoryFilter ? (
         <div className="mt-2 flex items-center justify-between gap-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className="inline-flex h-8 items-center gap-2 rounded-lg bg-slate-100 px-3 text-sm text-slate-700">
@@ -607,15 +749,15 @@ export function AssignmentsDashboard({ data }: AssignmentsDashboardProps) {
             }}
           >
             <TabsContent value="available-assets" className="flex min-h-0 flex-1 flex-col outline-none data-[state=inactive]:hidden">
-              {renderTable(filteredAvailableRows, selectionActionsAvailable, false)}
+              {renderTable(filteredAvailableRows, selectionActionsAvailable, false, "available")}
             </TabsContent>
 
             <TabsContent value="assigned-assets" className="flex min-h-0 flex-1 flex-col outline-none data-[state=inactive]:hidden">
-              {renderTable(filteredAssignedRows, selectionActionsAssigned, true)}
+              {renderTable(filteredAssignedRows, selectionActionsAssigned, true, "assigned")}
             </TabsContent>
 
             <TabsContent value="returned-assets" className="flex min-h-0 flex-1 flex-col outline-none data-[state=inactive]:hidden">
-              {renderTable(filteredReturnedRows, undefined, false)}
+              {renderTable(filteredReturnedRows, undefined, false, "returned")}
             </TabsContent>
           </ModuleNavigationTabs>
         </div>

--- a/src/components/features/operations/assignments/multi-asset-assignment-modal.tsx
+++ b/src/components/features/operations/assignments/multi-asset-assignment-modal.tsx
@@ -155,6 +155,17 @@ export function MultiAssetAssignmentModal({
       return;
     }
 
+    if (resolvedAssignmentMode === "user" && expectedReturn) {
+      const selectedDate = new Date(expectedReturn);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      if (selectedDate < today) {
+        tiqriToast.error("Select a valid date");
+        return;
+      }
+    }
+
     setIsSubmitting(true);
 
     const expectedDate = resolvedAssignmentMode === "user" ? expectedReturn || undefined : undefined;

--- a/src/components/features/operations/assignments/multi-asset-assignment-modal.tsx
+++ b/src/components/features/operations/assignments/multi-asset-assignment-modal.tsx
@@ -156,7 +156,8 @@ export function MultiAssetAssignmentModal({
     }
 
     if (resolvedAssignmentMode === "user" && expectedReturn) {
-      const selectedDate = new Date(expectedReturn);
+      const [year, month, day] = expectedReturn.split("-").map(Number);
+      const selectedDate = new Date(year, month - 1, day);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 

--- a/src/components/shared/data-table.tsx
+++ b/src/components/shared/data-table.tsx
@@ -260,25 +260,38 @@ export function DataTable<TData, TValue>({
 
   const tableContent = (
     <Table className="table-fixed min-w-full" containerClassName="!overflow-visible">
+      <colgroup>
+        {table.getFlatHeaders().map((header) => (
+          <col
+            key={header.id}
+            style={{
+              width: header.getSize(),
+              minWidth: header.getSize(),
+            }}
+          />
+        ))}
+      </colgroup>
       <TableHeader className="sticky top-0 z-10 bg-muted shadow-[0_1px_0] shadow-border [&_tr]:border-b-0">
         {selectedRows > 0 ? (
           <TableRow className="h-13.25 border-border bg-slate-500 hover:bg-slate-500">
             <TableHead
               colSpan={table.getAllLeafColumns().length}
-              className="h-13.25 bg-slate-500 px-6 py-0 font-medium text-white [&:has([role=checkbox])]:pr-6"
+              className="h-13.25 bg-slate-500 p-0 font-medium text-white"
             >
-              <div className="flex h-13.25 w-full items-center justify-between gap-4">
-                <div className="flex min-w-0 items-center gap-3" data-row-panel-ignore="true">
-                  <Checkbox
-                    aria-label="Select all rows"
-                    checked={
-                      table.getIsAllRowsSelected() ||
-                      (table.getIsSomeRowsSelected() ? "indeterminate" : false)
-                    }
-                    onCheckedChange={(value) => table.toggleAllRowsSelected(Boolean(value))}
-                    className="border-white/70 data-[state=checked]:border-white data-[state=checked]:bg-white data-[state=checked]:text-slate-600 data-[state=indeterminate]:border-white data-[state=indeterminate]:bg-white data-[state=indeterminate]:text-slate-600"
-                  />
-                  <p className="truncate text-sm font-medium text-white">
+              <div className="flex h-13.25 w-full items-center justify-between pr-6">
+                <div className="flex min-w-0 items-center">
+                  <div className="flex w-13 items-center justify-center" data-row-panel-ignore="true">
+                    <Checkbox
+                      aria-label="Select all rows"
+                      checked={
+                        table.getIsAllRowsSelected() ||
+                        (table.getIsSomeRowsSelected() ? "indeterminate" : false)
+                      }
+                      onCheckedChange={(value) => table.toggleAllRowsSelected(Boolean(value))}
+                      className="border-white/70 data-[state=checked]:border-white data-[state=checked]:bg-white data-[state=checked]:text-slate-600 data-[state=indeterminate]:border-white data-[state=indeterminate]:bg-white data-[state=indeterminate]:text-slate-600"
+                    />
+                  </div>
+                  <p className="truncate text-sm font-medium text-white ml-3">
                     {actionHeaderLabel}
                   </p>
                 </div>

--- a/src/components/shared/module-navigation-tabs.tsx
+++ b/src/components/shared/module-navigation-tabs.tsx
@@ -107,7 +107,7 @@ export const ModuleNavigationTabs = React.forwardRef<
         </TabsList>
 
         {/* ===== TAB CONTENT ===== */}
-        <div className="mt-4">
+        <div className="mt-4 flex flex-1 flex-col min-h-0">
           {/* If children provided, render them */}
           {children}
 

--- a/src/lib/data/operations-assignments-repo.ts
+++ b/src/lib/data/operations-assignments-repo.ts
@@ -809,7 +809,18 @@ export async function markAssignmentsAsReceived(
     })
     .from(assetAssignments)
     .innerJoin(assets, eq(assetAssignments.assetId, assets.id))
-    .where(inArray(assetAssignments.id, assignmentIds));
+    .where(
+      and(
+        inArray(assetAssignments.id, assignmentIds),
+        isNull(assetAssignments.returnedDate)
+      )
+    );
+
+  if (assignments.length === 0) {
+    return;
+  }
+
+  const activeAssignmentIds = assignments.map((a) => a.id);
 
   const assetIds = assignments.map((a) => a.assetId);
 
@@ -821,7 +832,7 @@ export async function markAssignmentsAsReceived(
         state: 'returned',
         returnedDate: new Date()
       })
-      .where(inArray(assetAssignments.id, assignmentIds));
+      .where(inArray(assetAssignments.id, activeAssignmentIds));
 
     // Update assets status back to 'Available'
     if (assetIds.length > 0) {

--- a/src/lib/data/operations-assignments-repo.ts
+++ b/src/lib/data/operations-assignments-repo.ts
@@ -1,4 +1,13 @@
-import { and, desc, eq, inArray, isNotNull, isNull, max, sql } from 'drizzle-orm';
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  max,
+  sql,
+} from 'drizzle-orm';
 
 import { db } from '@/db';
 import {
@@ -342,7 +351,12 @@ async function loadAssignedAssetsDirect(): Promise<AssignmentsDashboardRow[]> {
       eq(assetAssignments.id, latestActiveAssignments.latestAssignmentId)
     )
     .leftJoin(users, eq(assetAssignments.assignedToUserId, users.id))
-    .where(and(eq(assets.status, 'Assigned'), inArray(categories.pillar, DASHBOARD_PILLARS)))
+    .where(
+      and(
+        eq(assets.status, 'Assigned'),
+        inArray(categories.pillar, DASHBOARD_PILLARS)
+      )
+    )
     .orderBy(desc(assets.createdAt));
 
   return results.map((row) => ({
@@ -358,7 +372,9 @@ async function loadAssignedAssetsDirect(): Promise<AssignmentsDashboardRow[]> {
     assignedTo: row.assignedToUser || null,
     assignedToEmail: row.assignedToEmail || null,
     assignedDate: row.assignedDate,
-    expectedReturnDate: row.expectedReturnDate ? new Date(row.expectedReturnDate) : null,
+    expectedReturnDate: row.expectedReturnDate
+      ? new Date(row.expectedReturnDate)
+      : null,
     createdAt: row.createdAt || null,
     updatedAt: row.updatedAt || null,
     returnedDate: null,
@@ -427,7 +443,9 @@ async function loadReturnedAssets(): Promise<AssignmentsDashboardRow[]> {
   return [...returnedRowsByAssetId.values()];
 }
 
-export async function getAssignmentsDashboardData(tab?: AssignmentsDashboardTab): Promise<AssignmentsDashboardData> {
+export async function getAssignmentsDashboardData(
+  tab?: AssignmentsDashboardTab
+): Promise<AssignmentsDashboardData> {
   // Automatic refresh of overdue states on data load
   await refreshOverdueAssignments();
 
@@ -688,7 +706,12 @@ export async function getActiveAssignmentsByAssetIds(assetIds: string[]) {
  */
 export async function updateAssignmentsState(
   assignmentIds: number[],
-  newState: 'pending approval' | 'assigned' | 'overdue' | 'requested' | 'returned'
+  newState:
+    | 'pending approval'
+    | 'assigned'
+    | 'overdue'
+    | 'requested'
+    | 'returned'
 ): Promise<void> {
   if (assignmentIds.length === 0) return;
 
@@ -764,22 +787,15 @@ export async function triggerReturnRequests(
     // Update state to 'requested'
     await tx
       .update(assetAssignments)
-      .set({ 
+      .set({
         state: 'requested',
-        returnRequestedAt: new Date()
+        returnRequestedAt: new Date(),
       })
       .where(inArray(assetAssignments.id, assignmentIds));
 
-    // Send notifications and log audit
+    // Log audit
     await Promise.all(
       assignments.map(async (a) => {
-        await sendAssetNotification({
-          type: 'return_request',
-          recipientEmail: a.userEmail,
-          assetTag: a.assetTag,
-          assetName: a.assetName || a.assetTag,
-        });
-
         await logAuditActionTx(tx, {
           entityType: 'Asset',
           entityId: a.assetId,
@@ -791,6 +807,22 @@ export async function triggerReturnRequests(
       })
     );
   });
+
+  // Send notifications outside transaction
+  await Promise.allSettled(
+    assignments.map(async (a) => {
+      try {
+        await sendAssetNotification({
+          type: 'return_request',
+          recipientEmail: a.userEmail,
+          assetTag: a.assetTag,
+          assetName: a.assetName || a.assetTag,
+        });
+      } catch (error) {
+        console.error('Failed to send return request notification:', error);
+      }
+    })
+  );
 }
 
 /**
@@ -809,19 +841,29 @@ export async function markAssignmentsAsReceived(
     })
     .from(assetAssignments)
     .innerJoin(assets, eq(assetAssignments.assetId, assets.id))
-    .where(inArray(assetAssignments.id, assignmentIds));
+    .where(
+      and(
+        inArray(assetAssignments.id, assignmentIds),
+        isNull(assetAssignments.returnedDate)
+      )
+    );
 
+  if (assignments.length === 0) {
+    return;
+  }
+
+  const activeAssignmentIds = assignments.map((a) => a.id);
   const assetIds = assignments.map((a) => a.assetId);
 
   await db.transaction(async (tx) => {
     // Update assignments state to 'returned' and set returnedDate
     await tx
       .update(assetAssignments)
-      .set({ 
+      .set({
         state: 'returned',
-        returnedDate: new Date()
+        returnedDate: new Date(),
       })
-      .where(inArray(assetAssignments.id, assignmentIds));
+      .where(inArray(assetAssignments.id, activeAssignmentIds));
 
     // Update assets status back to 'Available'
     if (assetIds.length > 0) {

--- a/src/lib/data/operations-assignments-repo.ts
+++ b/src/lib/data/operations-assignments-repo.ts
@@ -10,7 +10,7 @@ import {
   models,
   users,
 } from '@/db/schema';
-import { logAuditActionTx } from '@/lib/audit';
+import { logAuditAction, logAuditActionTx } from '@/lib/audit';
 import type { AssetStatus } from '@/lib/data/asset-registry-repo';
 import { sendAssetNotification } from '../notifications';
 
@@ -539,6 +539,7 @@ export async function assignSingleAsset(
         assignedToUserId: target.assignedToUserId,
         assignedToLocationId: target.assignedToLocationId,
         expectedReturnDate,
+        state: 'pending approval',
       },
     });
 
@@ -642,6 +643,7 @@ export async function assignMultipleAssets(
             assignedToUserId: target.assignedToUserId,
             assignedToLocationId: target.assignedToLocationId,
             expectedReturnDate,
+            state: 'pending approval',
           },
         })
       )
@@ -699,10 +701,14 @@ export async function updateAssignmentsState(
 /**
  * Triggers a reminder notification for pending assignments.
  */
-export async function triggerAssignmentReminders(assignmentIds: number[]): Promise<void> {
+export async function triggerAssignmentReminders(
+  assignmentIds: number[],
+  performedById: string
+): Promise<void> {
   const assignments = await db
     .select({
       id: assetAssignments.id,
+      assetId: assetAssignments.assetId,
       assetTag: assets.assetTag,
       assetName: assets.name,
       userEmail: users.email,
@@ -713,24 +719,38 @@ export async function triggerAssignmentReminders(assignmentIds: number[]): Promi
     .where(inArray(assetAssignments.id, assignmentIds));
 
   await Promise.all(
-    assignments.map((a) =>
-      sendAssetNotification({
+    assignments.map(async (a) => {
+      // Send notification
+      await sendAssetNotification({
         type: 'assignment_reminder',
         recipientEmail: a.userEmail,
         assetTag: a.assetTag,
         assetName: a.assetName || a.assetTag,
-      })
-    )
+      });
+
+      // Log reminder action
+      await logAuditAction({
+        entityType: 'Asset',
+        entityId: a.assetId,
+        actionType: 'UPDATE',
+        performedById,
+        newData: { notificationSent: 'assignment_reminder' },
+      });
+    })
   );
 }
 
 /**
  * Triggers a return request and updates state to 'requested'.
  */
-export async function triggerReturnRequests(assignmentIds: number[]): Promise<void> {
+export async function triggerReturnRequests(
+  assignmentIds: number[],
+  performedById: string
+): Promise<void> {
   const assignments = await db
     .select({
       id: assetAssignments.id,
+      assetId: assetAssignments.assetId,
       assetTag: assets.assetTag,
       assetName: assets.name,
       userEmail: users.email,
@@ -744,19 +764,31 @@ export async function triggerReturnRequests(assignmentIds: number[]): Promise<vo
     // Update state to 'requested'
     await tx
       .update(assetAssignments)
-      .set({ state: 'requested' })
+      .set({ 
+        state: 'requested',
+        returnRequestedAt: new Date()
+      })
       .where(inArray(assetAssignments.id, assignmentIds));
 
-    // Send notifications
+    // Send notifications and log audit
     await Promise.all(
-      assignments.map((a) =>
-        sendAssetNotification({
+      assignments.map(async (a) => {
+        await sendAssetNotification({
           type: 'return_request',
           recipientEmail: a.userEmail,
           assetTag: a.assetTag,
           assetName: a.assetName || a.assetTag,
-        })
-      )
+        });
+
+        await logAuditActionTx(tx, {
+          entityType: 'Asset',
+          entityId: a.assetId,
+          actionType: 'UPDATE',
+          performedById,
+          oldData: { state: 'assigned' },
+          newData: { state: 'requested' },
+        });
+      })
     );
   });
 }
@@ -765,13 +797,18 @@ export async function triggerReturnRequests(assignmentIds: number[]): Promise<vo
  * Marks assets as received and updates state to 'returned'.
  * This also updates the asset status back to 'Available'.
  */
-export async function markAssignmentsAsReceived(assignmentIds: number[]): Promise<void> {
+export async function markAssignmentsAsReceived(
+  assignmentIds: number[],
+  performedById: string
+): Promise<void> {
   const assignments = await db
     .select({
       id: assetAssignments.id,
       assetId: assetAssignments.assetId,
+      assetTag: assets.assetTag,
     })
     .from(assetAssignments)
+    .innerJoin(assets, eq(assetAssignments.assetId, assets.id))
     .where(inArray(assetAssignments.id, assignmentIds));
 
   const assetIds = assignments.map((a) => a.assetId);
@@ -790,9 +827,23 @@ export async function markAssignmentsAsReceived(assignmentIds: number[]): Promis
     if (assetIds.length > 0) {
       await tx
         .update(assets)
-        .set({ status: 'Available' })
+        .set({ status: 'Available', updatedAt: new Date() })
         .where(inArray(assets.id, assetIds));
     }
+
+    // Log audit for each asset
+    await Promise.all(
+      assignments.map((a) =>
+        logAuditActionTx(tx, {
+          entityType: 'Asset',
+          entityId: a.assetId,
+          actionType: 'RETURN',
+          performedById,
+          oldData: { status: 'Assigned' },
+          newData: { status: 'Available' },
+        })
+      )
+    );
   });
 }
 

--- a/src/lib/validations/asset-assignment.ts
+++ b/src/lib/validations/asset-assignment.ts
@@ -6,10 +6,9 @@ const expectedReturnDateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/)
   .refine((date) => {
-    const selectedDate = new Date(date);
     const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return selectedDate >= today;
+    const todayString = today.toISOString().split('T')[0];
+    return date >= todayString;
   }, {
     message: "Select a valid date",
   })

--- a/src/lib/validations/asset-assignment.ts
+++ b/src/lib/validations/asset-assignment.ts
@@ -5,14 +5,19 @@ const assignmentTypeSchema = z.enum(['user', 'location']);
 const expectedReturnDateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/)
-  .refine((date) => {
-    const selectedDate = new Date(date);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return selectedDate >= today;
-  }, {
-    message: "Select a valid date",
-  })
+  .refine(
+    (date) => {
+      // Keep date local by splitting YYYY-MM-DD
+      const [year, month, day] = date.split('-').map(Number);
+      const selectedDate = new Date(year, month - 1, day);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      return selectedDate >= today;
+    },
+    {
+      message: 'Select a valid date',
+    }
+  )
   .optional();
 
 const notesSchema = z.string().max(2000).optional();
@@ -42,4 +47,6 @@ export const operationsAssignmentsQuerySchema = z.object({
 });
 
 export type AssignAssetPayload = z.infer<typeof assignAssetPayloadSchema>;
-export type BulkAssignAssetsPayload = z.infer<typeof bulkAssignAssetsPayloadSchema>;
+export type BulkAssignAssetsPayload = z.infer<
+  typeof bulkAssignAssetsPayloadSchema
+>;

--- a/src/lib/validations/asset-assignment.ts
+++ b/src/lib/validations/asset-assignment.ts
@@ -5,6 +5,14 @@ const assignmentTypeSchema = z.enum(['user', 'location']);
 const expectedReturnDateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .refine((date) => {
+    const selectedDate = new Date(date);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return selectedDate >= today;
+  }, {
+    message: "Select a valid date",
+  })
   .optional();
 
 const notesSchema = z.string().max(2000).optional();


### PR DESCRIPTION
**Description**
This PR implements User Story 14.3: Receiving an Asset (Mark as Returned) from Epic 14 (Asset Returns), enabling IT Admins to mark assigned assets as physically received when employees return them.

**Overview**
When an employee returns an assigned asset, IT Admins can now immediately mark it as "Received" through the Operations dashboard, formally ending the assignment and clearing the custodian relationship. The asset transitions to the "Returned Assets" tab for further inspection and condition assessment.

**Backend**

- markAssetReceivedAction() server action with GlobalAdmin/ITAdmin permission check
- Revalidates /operations/assignments and /assets paths
- markAssignmentsAsReceived() runs in a DB transaction — updates state to returned, stamps returnedDate, reverts asset to Available, creates audit entries
- Supports bulk operations
- New loadReturnedAssets() query added
- Active assignment queries updated to exclude returned records

**Frontend**

- Conditional "Received" button on assignment details panel for requested, overdue, and assigned states
- Panels wrapper connects button to server action with toast feedback; panel closes on success
- New "Returned Assets" tab on assignments dashboard with bulk selection, single-row operations, search/filter, and state transition tracking

closes #164 