### PR TITLE
feat: implement dual-authentication API routes for asset scanning and…

### DIFF
--- a/src/app/api/v1/issues/route.ts
+++ b/src/app/api/v1/issues/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth-options';
+import * as jose from 'jose';
+import { db } from '@/db';
+import { linkedDevices, maintenanceTickets, assets, assetAssignments, systemAuditLogs } from '@/db/schema';
+import { eq, and, isNull } from 'drizzle-orm';
+
+const MOBILE_SECRET = new TextEncoder().encode(
+  process.env.MOBILE_JWT_SECRET || 'default-fallback-mobile-jwt-secret-key-32bytes-minimum-length-for-hs256'
+);
+
+export async function POST(req: Request) {
+  let userId = null;
+  let userRole = null;
+
+  // --- 1. Check for Mobile App (Bearer Token) ---
+  const authHeader = req.headers.get('authorization');
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1];
+    try {
+      // Verify the custom mobile JWT we generated during the QR flow
+      const { payload } = await jose.jwtVerify(token, MOBILE_SECRET);
+
+      // Check that the JWT's jti maps to a non-revoked device
+      if (payload.jti) {
+        const [device] = await db
+          .select({ id: linkedDevices.id, isRevoked: linkedDevices.isRevoked })
+          .from(linkedDevices)
+          .where(
+            and(
+              eq(linkedDevices.jwtId, payload.jti),
+              eq(linkedDevices.isRevoked, false)
+            )
+          )
+          .limit(1);
+
+        if (!device) {
+          return NextResponse.json(
+            { error: 'Device has been unlinked. Please re-pair your device.' },
+            { status: 401 }
+          );
+        }
+
+        // Update lastActiveAt for this device
+        await db
+          .update(linkedDevices)
+          .set({ lastActiveAt: new Date() })
+          .where(eq(linkedDevices.id, device.id));
+      }
+
+      userId = payload.id;
+      userRole = payload.role;
+    } catch {
+      return NextResponse.json({ error: 'Invalid or Expired Mobile Token' }, { status: 401 });
+    }
+  } 
+  
+  // --- 2. Check for Web Dashboard (NextAuth Cookie) ---
+  else {
+    const session = await getServerSession(authOptions);
+    if (session?.user) {
+      userId = session.user.id;
+      userRole = session.user.role;
+    }
+  }
+
+  // --- 3. Final Security Check ---
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // --- 4. Execute Business Logic ---
+  try {
+    const body = await req.json();
+    const { assetId, issueNote } = body;
+
+    if (!assetId || !issueNote) {
+      return NextResponse.json({ error: 'assetId and issueNote are required' }, { status: 400 });
+    }
+
+    const result = await db.transaction(async (tx) => {
+      // Fetch the asset
+      const [currentAsset] = await tx
+        .select()
+        .from(assets)
+        .where(eq(assets.id, assetId))
+        .limit(1);
+
+      if (!currentAsset) {
+        throw new Error('Asset not found');
+      }
+
+      const now = new Date();
+
+      // Create internal maintenance ticket (this puts it in Pending Review)
+      const [newTicket] = await tx.insert(maintenanceTickets).values({
+        assetId: currentAsset.id,
+        ticketType: 'INTERNAL',
+        reportedIssue: issueNote,
+        status: 'ACTIVE',
+        dispatchedById: userId,
+        createdAt: now,
+        updatedAt: now,
+      }).returning();
+
+      if (!newTicket) {
+        throw new Error('Failed to create maintenance ticket');
+      }
+
+      // Update asset status to 'In Repair' (removing it from 'Available' assignments grid)
+      await tx
+        .update(assets)
+        .set({ status: 'In Repair', updatedAt: now })
+        .where(eq(assets.id, currentAsset.id));
+
+      // Terminate any active assignments since the asset is now In Repair
+      await tx
+        .update(assetAssignments)
+        .set({ returnedDate: now })
+        .where(
+          and(
+            eq(assetAssignments.assetId, currentAsset.id),
+            isNull(assetAssignments.returnedDate)
+          )
+        );
+
+      // Log the audit action
+      await tx.insert(systemAuditLogs).values({
+        entityType: 'Asset',
+        entityId: currentAsset.id,
+        actionType: 'UPDATE',
+        performedById: userId,
+        oldValue: { status: currentAsset.status },
+        newValue: {
+          status: 'In Repair',
+          actionContext: 'ISSUE_REPORTED_FROM_MOBILE',
+          issueNote: issueNote,
+        },
+        performedAt: now,
+      });
+
+      return {
+        success: true,
+        message: 'Issue reported successfully',
+        ticketId: newTicket.id,
+      };
+    });
+
+    return NextResponse.json(result);
+
+  } catch (error) {
+    console.error('Error reporting issue:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Internal Server Error';
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/scan/route.ts
+++ b/src/app/api/v1/scan/route.ts
@@ -5,6 +5,7 @@ import * as jose from 'jose';
 import { db } from '@/db';
 import { linkedDevices } from '@/db/schema';
 import { eq, and } from 'drizzle-orm';
+import { getAssetDetailsById } from '@/lib/data/asset-details-repo';
 
 const MOBILE_SECRET = new TextEncoder().encode(
   process.env.MOBILE_JWT_SECRET || 'default-fallback-mobile-jwt-secret-key-32bytes-minimum-length-for-hs256'
@@ -73,7 +74,35 @@ export async function POST(req: Request) {
   // --- 4. Execute Business Logic ---
   console.log(`Scan initiated by user ${userId} with role ${userRole}`);
   
-  // Process the QR scan in your Drizzle database...
+  let assetTag: string | null = null;
+  try {
+    const body = await req.json();
+    let rawTag = body.assetTag;
+    if (typeof rawTag === 'string') {
+      // If the QR code contains a full URL (e.g. https://.../assets/LAP-001)
+      if (rawTag.includes('/assets/')) {
+        rawTag = rawTag.split('/assets/').pop()?.split('?')[0] || rawTag;
+      }
+      // Clean up any trailing slashes or spaces
+      assetTag = rawTag.trim().replace(/\/+$/, '');
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  if (!assetTag) {
+    return NextResponse.json({ error: 'Asset tag is required' }, { status: 400 });
+  }
+
+  const assetDetails = await getAssetDetailsById(assetTag);
+
+  if (!assetDetails) {
+    return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
+  }
   
-  return NextResponse.json({ success: true, message: 'Asset Scanned Successfully' });
+  return NextResponse.json({ 
+    success: true, 
+    message: 'Asset Scanned Successfully',
+    data: assetDetails
+  });
 }


### PR DESCRIPTION
## Description
This PR implements dual-authentication API routes to support asset scanning and issue reporting, particularly bridging the gap between the mobile application and the web dashboard. 

## Key Changes
- **New Issue Reporting API (`/api/v1/issues`)**:
  - Added a `POST` route that accepts `assetId` and `issueNote`.
  - Implements a dual-authentication check: validates either the custom Mobile JWT (Bearer token from paired mobile devices) or the NextAuth session cookie (for web dashboard access).
  - Executes a database transaction to:
    - Create an internal maintenance ticket for the reported issue.
    - Update the asset status to "In Repair" so it's no longer available for assignment.
    - Terminate any active assignments for the asset.
    - Write a detailed record to the system audit logs.
- **Enhanced Scan API (`/api/v1/scan`)**:
  - Updated the `POST` route to extract the asset tag from the request payload.
  - Added robust parsing to handle full URL QR codes (e.g., `https://.../assets/LAP-001`), properly extracting just the ID.
  - Integrated `getAssetDetailsById` to return the complete asset details in the response for immediate consumption by the mobile app upon scanning.