### PR TITLE
feat: software bulk actions, All Assets header, e2e and audit fixes

### DIFF
--- a/docs/AUDIT_REPORT_2026-08-31.md
+++ b/docs/AUDIT_REPORT_2026-08-31.md
@@ -27,7 +27,7 @@ The `api` alternative is a prefix, not a path segment, so it also excludes
 ```
 
 The Swagger page is therefore reachable without a session. The spec it fetches
-(`/api/openapi.json`) *is* guarded by `withSessionAuth`, so an anonymous
+(`/api/openapi.json`) _is_ guarded by `withSessionAuth`, so an anonymous
 visitor sees the page shell and an error, not the API surface. The exposure is
 the page itself, not the documentation.
 

--- a/docs/AUDIT_REPORT_2026-08-31.md
+++ b/docs/AUDIT_REPORT_2026-08-31.md
@@ -1,0 +1,171 @@
+# Code audit — 31 August 2026
+
+Scan of security, performance and code quality across `src/`, the proxy, the
+migrations and the e2e suite. Each finding records what was checked, what was
+found, and what was done about it.
+
+Findings marked **Fixed** were implemented in the same change as this document.
+Findings marked **Reported** were left alone deliberately — the reason is given.
+
+---
+
+## Security
+
+### S1 — `/api-docs` bypasses authentication entirely — Reported
+
+`src/proxy.ts` matcher:
+
+```
+'/((?!api|_next/static|_next/image|favicon.ico|manifest.json|sw.js|icons).*)'
+```
+
+The `api` alternative is a prefix, not a path segment, so it also excludes
+`/api-docs/*`. Verified:
+
+```
+/api-docs/index.html  -> proxy runs: false
+```
+
+The Swagger page is therefore reachable without a session. The spec it fetches
+(`/api/openapi.json`) *is* guarded by `withSessionAuth`, so an anonymous
+visitor sees the page shell and an error, not the API surface. The exposure is
+the page itself, not the documentation.
+
+Not changed here because tightening the matcher to `api/` alters routing for
+every request and deserves its own change with its own verification. The fix is
+to anchor the alternative to a segment boundary:
+
+```
+'/((?!api/|_next/static|…).*)'
+```
+
+`isPublicAssetPath()` needs the same treatment — it uses
+`!pathname.startsWith('/api')` for the same purpose.
+
+### S2 — Assignment pillar rules are enforced only in the browser — Reported
+
+`MultiAssetAssignmentModal` decides that software goes to a person and office
+assets go to a location, and blocks a batch spanning both.
+`validateAssetsForAssignment()` in `operations-assignments-repo.ts` checks
+existence and status only — it never looks at the category pillar. A direct call
+to `bulkAssignAssetsAction` can still assign a desk to a person.
+
+Left for a separate change: adding the check means joining `models` →
+`categories` inside the assignment path and deciding what to do with the
+existing rows that already violate it. Worth doing, but not silently.
+
+### S3 — `setPreferredCurrency` wrote an unvalidated, unhardened cookie — Fixed
+
+`src/actions/currency.ts` accepted any string and stored it with only
+`path: '/'`:
+
+```ts
+cookieStore.set('preferred_currency', currencyCode, { path: '/' });
+```
+
+Two problems. The value was never checked against `SUPPORTED_CURRENCIES`, so
+arbitrary content could be written to a cookie the server later reads and passes
+around as a currency code. And the cookie carried no `sameSite`, `httpOnly` or
+`secure` flags.
+
+Rendering never crashed on it — `resolveCurrencyCode()` falls back to `LKR` for
+anything unrecognised — so this was defence in depth rather than a live bug.
+Now the value is validated at the boundary and the cookie is hardened. It is
+read only in server components (`layout.tsx`, `disposals/page.tsx`), never via
+`document.cookie`, so `httpOnly` is safe.
+
+---
+
+## Performance
+
+### P1 — Bulk import opens one transaction per row — Reported
+
+`bulk-import.ts` wraps each row in its own `db.transaction`. For a large import
+that is one round trip per row.
+
+Deliberately left alone: the loop collects `failedRows` and continues past
+individual failures, which is only possible because each row commits or rolls
+back on its own. Batching would trade that per-row isolation for throughput, and
+that is a product decision, not a cleanup.
+
+### P2 — 23 unprojected `.select()` calls — Reported
+
+`src/actions` and `src/lib/data` contain 23 `.select()` calls with no column
+list, which fetch every column of the joined tables. Several feed views that use
+two or three fields.
+
+Not changed in bulk: each one needs checking against its consumers to avoid
+dropping a field something reads, and a sweeping change here is a large diff
+with a real regression surface for little measured gain. Worth doing per-query
+when those paths are next touched, guided by a measurement rather than a grep.
+
+---
+
+## Code quality
+
+### Q1 — e2e assertions could not fail — Fixed
+
+`DashboardPage.expectToBeVisible()` asserted two things, neither of which tested
+anything:
+
+```ts
+await expect(this.page).toHaveURL(/\/?$/);          // matches every string
+await expect(...).toBeVisible().catch(() => {});     // failure swallowed
+```
+
+`/\/?$/` matches any input, because `\/?` is optional and `$` matches the end of
+any string. The heading check discarded its own rejection. Both `auth.spec.ts`
+tests using it passed regardless of what the app did — including for an
+Employee, who has no dashboard at all and is redirected to `/my-assets`.
+
+Replaced with `expectLandedOn(pathname, heading)`, which asserts the real
+destination per role and a real heading. Navigations also moved to
+`waitUntil: 'domcontentloaded'`; the app streams and holds connections open, and
+waiting for full `load` was intermittently sitting until the 30s timeout — the
+cause of the flaky Employee failures seen in CI.
+
+### Q2 — `reportDefectiveFromPanel` is dead — Reported
+
+Since the detail panel moved to `flagAssetForRepair`, the only remaining
+references to `reportDefectiveFromPanel` are its own tests. It is still exported
+from `src/actions/maintenance.ts`.
+
+Left in place: deleting a server action and its tests is a separate, easily
+reviewed change, and it is harmless where it sits.
+
+### Q3 — `setState` inside effects — Fixed
+
+Two components scheduled a render, then corrected themselves in an effect:
+
+- `edit-user-role-modal.tsx` reset form state in a `useEffect`
+- `use-assignment-modal-state.ts` corrected an invalid assignment mode
+
+Both fail `react-hooks/set-state-in-effect`, which is an **error** in this
+repo's config, so both broke `npm run check` in CI. Both now derive during
+render — the modal by comparing against previous props, the hook by correcting
+the mode as it is read.
+
+### Q4 — Stale `react-hooks/exhaustive-deps` warning — Fixed
+
+`use-registration-form.ts:231` omitted `MAX_INVOICE_FILE_SIZE` from a
+`useCallback` dependency list. It is a module constant, so the behaviour was
+never wrong, but it was the only lint warning left in the repo and it hid
+anything new appearing beside it.
+
+---
+
+## Verified healthy
+
+Checks that came back clean, recorded so the next audit need not redo them:
+
+- No `dangerouslySetInnerHTML`, `eval()` or `new Function()` in application code.
+  The one `redis.eval` in `bulk-import.ts` is a Redis Lua script, not JS eval.
+- No `console.log` left in `src/actions` or `src/lib`.
+- Every exported server action reaches an auth guard. Two files initially looked
+  unguarded; both were false positives — `disposals/execute.ts` uses
+  `enforceFormAccess`, and `currency.ts` sets a UI preference that needs no
+  session.
+- `npm audit --audit-level=high` is clean (5 moderate advisories, all
+  `postcss` transitives).
+- All SQL goes through Drizzle's parameterised builders. The `sql` template
+  interpolations are column and table references, not user input.

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -31,9 +31,13 @@ export class DashboardPage {
    * the app did.
    */
   async expectLandedOn(pathname: RegExp, heading: RegExp) {
-    await expect(this.page).toHaveURL(pathname);
-    await expect(
-      this.page.getByRole('heading', { name: heading })
-    ).toBeVisible();
+    // `waitForURL`, not `toHaveURL`: `/` returns a 200 shell and redirects from
+    // the client once hydrated, so the browser sits on `/` for a moment. On a
+    // cold CI runner the session call alone took 4.6s, past the 5s default
+    // expect timeout, which read as "never redirected" rather than "not yet".
+    await this.page.waitForURL(pathname, { timeout: 30_000 });
+    await expect(this.page.getByRole('heading', { name: heading })).toBeVisible(
+      { timeout: 15_000 }
+    );
   }
 }

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -1,5 +1,13 @@
 import { Page, expect } from '@playwright/test';
 
+/**
+ * The landing page for a signed-in user.
+ *
+ * Which page that is depends on the role: only roles with a dashboard land on
+ * /dashboard, while an Employee is redirected to /my-assets. Both are reached
+ * by opening `/`, so the destination is an assertion the caller makes rather
+ * than something this object assumes.
+ */
 export class DashboardPage {
   readonly page: Page;
 
@@ -8,17 +16,24 @@ export class DashboardPage {
   }
 
   async goto() {
-    await this.page.goto('/');
+    // `domcontentloaded` rather than the default `load`: the app streams and
+    // keeps connections open, so waiting for full load intermittently sat
+    // until the 30s timeout even though the page was interactive.
+    await this.page.goto('/', { waitUntil: 'domcontentloaded' });
   }
 
-  async expectToBeVisible() {
-    // Wait for a dashboard specific element or URL
-    await expect(this.page).toHaveURL(/\/?$/);
-    // You could also wait for a heading like "Dashboard"
-    await expect(this.page.locator('h1', { hasText: /Dashboard/i }))
-      .toBeVisible({ timeout: 10000 })
-      .catch(() => {
-        // sometimes dashboard might just have some specific role text or welcome
-      });
+  /**
+   * Asserts where the redirect landed and that the page actually rendered.
+   *
+   * The URL check used to be `toHaveURL(/\/?$/)`, a pattern every string
+   * matches, and the heading check swallowed its own failure in a `.catch()`.
+   * Between them the assertion could not fail, so these specs passed whatever
+   * the app did.
+   */
+  async expectLandedOn(pathname: RegExp, heading: RegExp) {
+    await expect(this.page).toHaveURL(pathname);
+    await expect(
+      this.page.getByRole('heading', { name: heading })
+    ).toBeVisible();
   }
 }

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -13,27 +13,26 @@ test.describe('Authentication Strategy', () => {
     await loginPage.clickLogin();
     // This requires a real test user to exist in the configured Keycloak instance
     await loginPage.performRealLogin('test_employee', 'password123');
-    await dashboardPage.expectToBeVisible();
+    await dashboardPage.expectLandedOn(/\/my-assets$/, /My Assets/i);
   });
 
   // Test 2: Verify that our test bypass fixture works for an Admin
   test('Bypass Login - GlobalAdmin', async ({ adminPage, dashboardPage }) => {
     // adminPage fixture automatically creates session and injects the cookie
-    await dashboardPage.goto(); // Go to dashboard directly
-    await dashboardPage.expectToBeVisible();
+    await dashboardPage.goto();
 
-    // We can also verify that the UI shows admin specific elements,
-    // e.g., an Admin Settings link in the navigation
-    // This depends on your actual app layout, but for now we verify the URL
-    await expect(adminPage).toHaveURL(/\/?$/);
+    // A GlobalAdmin has a dashboard, so `/` resolves to it.
+    await dashboardPage.expectLandedOn(/\/dashboard$/, /Welcome back/i);
+    await expect(adminPage).toHaveURL(/\/dashboard$/);
   });
 
   // Test 3: Verify that our test bypass fixture works for an Employee
   test('Bypass Login - Employee', async ({ employeePage, dashboardPage }) => {
     // employeePage fixture automatically creates session and injects the cookie
     await dashboardPage.goto();
-    await dashboardPage.expectToBeVisible();
 
-    await expect(employeePage).toHaveURL(/\/?$/);
+    // Employees have no dashboard; the proxy sends them to their own assets.
+    await dashboardPage.expectLandedOn(/\/my-assets$/, /My Assets/i);
+    await expect(employeePage).toHaveURL(/\/my-assets$/);
   });
 });

--- a/e2e/tests/rbac.spec.ts
+++ b/e2e/tests/rbac.spec.ts
@@ -28,11 +28,11 @@ test.describe('Role boundary', () => {
   }) => {
     // Control: the session is valid and the role is read correctly. Employees
     // have no dashboard, so they are sent to /my-assets.
-    await employeePage.goto('/');
+    await employeePage.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(employeePage).toHaveURL(/\/my-assets$/);
 
     // The boundary.
-    await employeePage.goto('/financials');
+    await employeePage.goto('/financials', { waitUntil: 'domcontentloaded' });
     await expect(employeePage).toHaveURL(/\/403$/);
     await expect(employeePage.getByText('403 - Access Denied')).toBeVisible();
   });

--- a/e2e/tests/rbac.spec.ts
+++ b/e2e/tests/rbac.spec.ts
@@ -29,11 +29,11 @@ test.describe('Role boundary', () => {
     // Control: the session is valid and the role is read correctly. Employees
     // have no dashboard, so they are sent to /my-assets.
     await employeePage.goto('/', { waitUntil: 'domcontentloaded' });
-    await expect(employeePage).toHaveURL(/\/my-assets$/);
+    await employeePage.waitForURL(/\/my-assets$/, { timeout: 30_000 });
 
     // The boundary.
     await employeePage.goto('/financials', { waitUntil: 'domcontentloaded' });
-    await expect(employeePage).toHaveURL(/\/403$/);
+    await employeePage.waitForURL(/\/403$/, { timeout: 30_000 });
     await expect(employeePage.getByText('403 - Access Denied')).toBeVisible();
   });
 });

--- a/src/actions/currency.ts
+++ b/src/actions/currency.ts
@@ -2,7 +2,29 @@
 
 import { cookies } from 'next/headers';
 
+import { isSupportedCurrency } from '@/lib/currency';
+
+/**
+ * Stores the viewer's display currency.
+ *
+ * The value is checked against the supported set rather than trusted: this is
+ * a server action, so the argument is whatever the caller sent, and it is read
+ * back on later requests and passed around as a currency code. Rendering
+ * survives a bad value -- `resolveCurrencyCode` falls back to LKR -- but there
+ * is no reason to persist junk in the first place.
+ *
+ * Read only by server components, never `document.cookie`, so `httpOnly` costs
+ * nothing here.
+ */
 export async function setPreferredCurrency(currencyCode: string) {
+  if (!isSupportedCurrency(currencyCode)) return;
+
   const cookieStore = await cookies();
-  cookieStore.set('preferred_currency', currencyCode, { path: '/' });
+  cookieStore.set('preferred_currency', currencyCode, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 60 * 60 * 24 * 365,
+  });
 }

--- a/src/components/features/asset-registry/asset-registry-client.tsx
+++ b/src/components/features/asset-registry/asset-registry-client.tsx
@@ -11,6 +11,8 @@ import { type RegistryViewConfig } from '@/components/features/asset-registry/re
 import { DataTable } from '@/components/shared/data-table';
 import { DisposeAssetsRequestDialog } from '@/components/features/disposals/dispose-assets-request-dialog';
 import { BulkTransferDialog } from '@/components/features/asset-registry/bulk-transfer-dialog';
+import { AddSoftwareUsersModal } from '@/components/features/asset-registry/panels/add-software-users-modal';
+import { RenewLicenseDialog } from '@/components/features/asset-registry/panels/renew-license-dialog';
 import { AssetPillarSelectionDialog } from '@/components/shared/asset-pillar-selection-dialog';
 import {
   FilterBar,
@@ -28,6 +30,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { isSoftwareLicenseExpired } from '@/lib/software-license-status';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +38,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
+import type { Row, RowSelectionState } from '@tanstack/react-table';
 import type {
   AssetRegistryCategory,
   AssetRegistryResult,
@@ -325,6 +329,36 @@ export function AssetRegistryClient({
   // Selection actions
   // -------------------------------------------------------------------------
 
+  // Selection is lifted out of the table so software rows can be kept to one
+  // kind at a time: an expired licence and a live one need different actions,
+  // and a mixed selection could satisfy neither.
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [softwareActionRows, setSoftwareActionRows] = useState<
+    AssetRegistryRow[]
+  >([]);
+  const [isSoftwareAssignOpen, setIsSoftwareAssignOpen] = useState(false);
+  const [isSoftwareRenewOpen, setIsSoftwareRenewOpen] = useState(false);
+
+  const selectedSoftwareKind = useMemo<'expired' | 'available' | null>(() => {
+    if (config.view !== 'software') return null;
+    const selected = filteredRows.filter((row) => rowSelection[row.id]);
+    if (selected.length === 0) return null;
+    return selected.some((row) => isSoftwareLicenseExpired(row.expiryDate))
+      ? 'expired'
+      : 'available';
+  }, [config.view, filteredRows, rowSelection]);
+
+  const canSelectRow = useMemo(() => {
+    if (config.view !== 'software') return true;
+    return (row: Row<AssetRegistryRow>) => {
+      if (selectedSoftwareKind === null) return true;
+      const kind = isSoftwareLicenseExpired(row.original.expiryDate)
+        ? 'expired'
+        : 'available';
+      return kind === selectedSoftwareKind;
+    };
+  }, [config.view, selectedSoftwareKind]);
+
   const selectionActions = useMemo(
     () =>
       buildSelectionActions(config, isMutating, {
@@ -343,6 +377,29 @@ export function AssetRegistryClient({
           setDisposalSelectionRows(selectedRowsForAction);
           setIsDisposalDialogOpen(true);
         },
+        // Seats and renewal terms are per licence, so both flows act on one
+        // row. The bulk buttons still gate on the whole selection, which is
+        // what decides whether Assign or Renew is the sensible action at all.
+        onAssignSoftware: (selectedRowsForAction) => {
+          if (selectedRowsForAction.length !== 1) {
+            tiqriToast.info(
+              'Allocate seats one licence at a time -- each has its own seat count.'
+            );
+            return;
+          }
+          setSoftwareActionRows(selectedRowsForAction);
+          setIsSoftwareAssignOpen(true);
+        },
+        onRenewSoftware: (selectedRowsForAction) => {
+          if (selectedRowsForAction.length !== 1) {
+            tiqriToast.info(
+              'Renew one licence at a time -- each has its own term and seat count.'
+            );
+            return;
+          }
+          setSoftwareActionRows(selectedRowsForAction);
+          setIsSoftwareRenewOpen(true);
+        },
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [config, isMutating]
@@ -356,40 +413,53 @@ export function AssetRegistryClient({
 
   return (
     <main className="flex min-h-0 min-w-0 flex-1 flex-col rounded-xl bg-background p-6">
-      {/* Category selector header */}
+      {/* Category selector header.
+
+          All Assets is the whole registry, so there is nothing for the picker
+          to switch to that the sidebar does not already offer -- it reads as a
+          filter that does not filter. The pillar views keep it, where moving
+          between sibling categories is the point. */}
       <div className="mb-4">
-        <Popover
-          open={isCategoryPopoverOpen}
-          onOpenChange={setIsCategoryPopoverOpen}
-        >
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className={`inline-flex items-center gap-2 ${TYPOGRAPHY_CLASSNAMES.text2xlSemiBold} text-foreground`}
-            >
-              <span>{selectedCategoryOption.name}</span>
-              <ChevronDown className="size-5 text-foreground mt-1" />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent
-            align="start"
-            sideOffset={10}
-            className="w-fit rounded-lg border border-border p-2 shadow-xl"
+        {config.view === 'unified' ? (
+          <h1
+            className={`${TYPOGRAPHY_CLASSNAMES.text2xlSemiBold} text-foreground`}
           >
-            <div className="w-max space-y-1">
-              {categoryOptions.map((categoryOption) => (
-                <button
-                  key={categoryOption.name}
-                  type="button"
-                  className="flex w-full items-center whitespace-nowrap rounded-md px-2 py-1 text-left text-sm font-semibold leading-5 text-foreground hover:bg-muted"
-                  onClick={() => handleCategorySelect(categoryOption.name)}
-                >
-                  {categoryOption.name}
-                </button>
-              ))}
-            </div>
-          </PopoverContent>
-        </Popover>
+            {selectedCategoryOption.name}
+          </h1>
+        ) : (
+          <Popover
+            open={isCategoryPopoverOpen}
+            onOpenChange={setIsCategoryPopoverOpen}
+          >
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className={`inline-flex items-center gap-2 ${TYPOGRAPHY_CLASSNAMES.text2xlSemiBold} text-foreground`}
+              >
+                <span>{selectedCategoryOption.name}</span>
+                <ChevronDown className="size-5 text-foreground mt-1" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              sideOffset={10}
+              className="w-fit rounded-lg border border-border p-2 shadow-xl"
+            >
+              <div className="w-max space-y-1">
+                {categoryOptions.map((categoryOption) => (
+                  <button
+                    key={categoryOption.name}
+                    type="button"
+                    className="flex w-full items-center whitespace-nowrap rounded-md px-2 py-1 text-left text-sm font-semibold leading-5 text-foreground hover:bg-muted"
+                    onClick={() => handleCategorySelect(categoryOption.name)}
+                  >
+                    {categoryOption.name}
+                  </button>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
 
       <div className="mt-4 flex min-h-0 flex-1 flex-col gap-4">
@@ -460,6 +530,9 @@ export function AssetRegistryClient({
                   : [{ id: 'assetTag', desc: true }]
               }
               selectionActions={selectionActionsToDisplay}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
+              enableRowSelection={canSelectRow}
               selectionLabel={(selectedCount) =>
                 `${selectedCount} Assets Selected`
               }
@@ -548,6 +621,33 @@ export function AssetRegistryClient({
           selectedCount={printSelectionRows.length}
           onGenerate={handlePrintGenerate}
         />
+
+        {softwareActionRows[0] ? (
+          <AddSoftwareUsersModal
+            isOpen={isSoftwareAssignOpen}
+            onClose={(didAllocate) => {
+              setIsSoftwareAssignOpen(false);
+              setSoftwareActionRows([]);
+              if (didAllocate) setRefreshNonce((n) => n + 1);
+            }}
+            assetId={softwareActionRows[0].id}
+            availableSeats={softwareActionRows[0].availableSeats ?? 0}
+          />
+        ) : null}
+
+        {softwareActionRows[0] ? (
+          <RenewLicenseDialog
+            isOpen={isSoftwareRenewOpen}
+            assetId={softwareActionRows[0].id}
+            currentExpiry={softwareActionRows[0].expiryDate}
+            currentSeats={softwareActionRows[0].totalSeats}
+            onOpenChange={(open) => {
+              setIsSoftwareRenewOpen(open);
+              if (!open) setSoftwareActionRows([]);
+            }}
+            onRenewed={() => setRefreshNonce((n) => n + 1)}
+          />
+        ) : null}
 
         <AssetPillarSelectionDialog
           open={isPillarDialogOpen}

--- a/src/components/features/asset-registry/asset-registry-helpers.ts
+++ b/src/components/features/asset-registry/asset-registry-helpers.ts
@@ -1,3 +1,4 @@
+import { isSoftwareLicenseExpired } from '@/lib/software-license-status';
 import type {
   RegistryFilterField,
   RegistryViewConfig,
@@ -143,6 +144,8 @@ export function buildSelectionActions(
     ) => void;
     onBulkTransfer: (rows: AssetRegistryRow[]) => void;
     onDispose: (rows: AssetRegistryRow[]) => void;
+    onAssignSoftware: (rows: AssetRegistryRow[]) => void;
+    onRenewSoftware: (rows: AssetRegistryRow[]) => void;
   }
 ): DataTableSelectionAction<AssetRegistryRow>[] {
   const actions: DataTableSelectionAction<AssetRegistryRow>[] = [
@@ -174,6 +177,31 @@ export function buildSelectionActions(
         );
       },
     });
+  }
+
+  // Software rows offer one action or the other, never both: an expired licence
+  // has to be renewed before it can be handed to anyone, and renewing a live
+  // one is meaningless. The table also stops the two kinds being selected
+  // together, so a selection is always uniformly one or the other.
+  if (config.view === 'software') {
+    actions.push({
+      id: 'assign-software',
+      label: 'Assign',
+      disabled: isMutating,
+      hidden: (selectedRows) =>
+        selectedRows.some((row) => isSoftwareLicenseExpired(row.expiryDate)),
+      onClick: callbacks.onAssignSoftware,
+    } as DataTableSelectionAction<AssetRegistryRow>);
+
+    actions.push({
+      id: 'renew-software',
+      label: 'Renew',
+      disabled: isMutating,
+      hidden: (selectedRows) =>
+        selectedRows.length === 0 ||
+        !selectedRows.every((row) => isSoftwareLicenseExpired(row.expiryDate)),
+      onClick: callbacks.onRenewSoftware,
+    } as DataTableSelectionAction<AssetRegistryRow>);
   }
 
   if (config.view !== 'software') {

--- a/src/components/features/asset-registry/panels/use-registration-form.ts
+++ b/src/components/features/asset-registry/panels/use-registration-form.ts
@@ -67,6 +67,10 @@ interface UseRegistrationFormProps {
   onRegistrationSuccess?: (assetId: string, modelName: string) => void;
 }
 
+/** 4.5 MB -- matches the server limit in storage.ts. Module scope so it is
+ * not a reactive value the callbacks below have to list as a dependency. */
+const MAX_INVOICE_FILE_SIZE = Math.floor(4.5 * 1024 * 1024);
+
 export function useRegistrationForm({
   initialPillar,
   categoryOptions = [],
@@ -195,8 +199,6 @@ export function useRegistrationForm({
       setCostPerSeat('0.00');
     }
   }, []);
-
-  const MAX_INVOICE_FILE_SIZE = Math.floor(4.5 * 1024 * 1024); // 4.5 MB — matches server limit in storage.ts
 
   const handleInvoiceSelection = useCallback((files: FileList | null) => {
     const selectedFile = files?.[0] ?? null;

--- a/src/components/shared/software-expiry-status.tsx
+++ b/src/components/shared/software-expiry-status.tsx
@@ -1,5 +1,6 @@
 import { differenceInDays } from 'date-fns';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { isSoftwareLicenseExpired } from '@/lib/software-license-status';
 import { cn } from '@/lib/utils';
 
 interface SoftwareExpiryStatusProps {
@@ -18,7 +19,7 @@ export function SoftwareExpiryStatus({
 
   if (expiryDate) {
     const daysLeft = differenceInDays(new Date(expiryDate), new Date());
-    if (daysLeft < 0) {
+    if (isSoftwareLicenseExpired(expiryDate)) {
       daysLeftText = 'Expired';
       daysLeftClass = 'text-red-600 font-medium';
     } else {

--- a/src/lib/software-license-status.ts
+++ b/src/lib/software-license-status.ts
@@ -1,3 +1,5 @@
+import { differenceInDays } from 'date-fns';
+
 export const SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT = 80;
 
 export function isSoftwareLicenseNearCapacity(
@@ -14,4 +16,20 @@ export function isSoftwareLicenseNearCapacity(
     assignedSeats * 100 >=
       totalSeats * SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT
   );
+}
+
+/**
+ * A licence is expired once its expiry date is in the past. No date at all
+ * means a perpetual licence, which never expires.
+ *
+ * Shared so the badge and the bulk-selection rules agree on what "expired"
+ * means -- they are what decide whether a row offers Renew or Assign.
+ */
+export function isSoftwareLicenseExpired(
+  expiryDate?: string | Date | null
+): boolean {
+  if (!expiryDate) return false;
+  const parsed = new Date(expiryDate);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return differenceInDays(parsed, new Date()) < 0;
 }


### PR DESCRIPTION
Completes the three outstanding items from Chamodi's list that no open PR covered, fixes the e2e suite, and lands the fixes from a code audit.

**Features**
- All Assets header is plain text; the category picker stays on the pillar views where switching between siblings is the point.
- Software rows get Assign / Renew bulk actions, shown one at a time: Assign for live licences, Renew once every selected row is expired.
- Selecting an expired licence disables the live ones and vice versa, so a selection is always uniformly one kind. `enableRowSelection` already accepted a predicate; selection state is lifted so the predicate can see it.
- `isSoftwareLicenseExpired` extracted so the badge and the selection rules agree on what expired means.

**e2e**
`DashboardPage.expectToBeVisible()` asserted `toHaveURL(/\/?$/)` -- a pattern every string matches -- and swallowed its heading check in `.catch(() => {})`. Neither assertion could fail, including for an Employee who has no dashboard. Replaced with per-role destination and heading assertions, and navigations no longer wait on full `load`, which is what made the Employee specs time out intermittently in CI.

**Audit** (docs/AUDIT_REPORT_2026-08-31.md)
- Validated and hardened the preferred-currency cookie (was unvalidated, no sameSite/httpOnly/secure).
- Hoisted `MAX_INVOICE_FILE_SIZE` out of the hook scope; lint is now clean with zero warnings.
- Three findings documented and deliberately left: `/api-docs` bypassing the proxy, assignment pillar rules being client-only, and unprojected selects. Each says why.

tsc, lint, 1306 tests and build all green.