### PR TITLE
fix(software): seat warning at 10% remaining; seed report templates

### DIFF
--- a/scripts/seed-demo-data.mts
+++ b/scripts/seed-demo-data.mts
@@ -893,7 +893,242 @@ async function run() {
       }
       summary.push(`notifications: ${notes}`);
 
-      // ── 13. Integrations, devices and delivery logs ─────────────────────
+      // ── 13. Saved report templates ──────────────────────────────────────
+      // Field names are copied from REPORT_FIELD_OPTIONS_BY_SOURCE and the
+      // filter keys are the ones the fetchers actually read, so each template
+      // runs rather than just looking plausible in the list. A test asserts
+      // the two stay in step.
+      await tx`DELETE FROM report_templates`;
+      const TEMPLATES: Array<{
+        name: string;
+        code: string;
+        description: string;
+        source: string;
+        filters: Record<string, string>;
+        fields: string[];
+      }> = [
+        {
+          name: 'Hardware register',
+          code: 'RPT-2026-001',
+          description:
+            'Every hardware asset with its custodian, location and purchase cost.',
+          source: 'Assets',
+          filters: { assetType: 'Hardware' },
+          fields: [
+            'Asset Tag',
+            'Asset Name',
+            'Category',
+            'Brand',
+            'Model',
+            'Serial Number',
+            'Status',
+            'Location',
+            'Assigned To',
+            'Purchase Cost',
+          ],
+        },
+        {
+          name: 'Office furniture by location',
+          code: 'RPT-2026-002',
+          description: 'Furniture holdings for the annual floor audit.',
+          source: 'Assets',
+          filters: { assetType: 'Office Furniture' },
+          fields: [
+            'Asset Tag',
+            'Asset Name',
+            'Category',
+            'Location',
+            'Status',
+            'Purchase Date',
+            'Purchase Cost',
+          ],
+        },
+        {
+          name: 'Assets currently on loan',
+          code: 'RPT-2026-003',
+          description: 'Open assignments and how long each has been out.',
+          source: 'Active Assignments',
+          filters: {},
+          fields: [
+            'Asset Tag',
+            'Asset Name',
+            'Assigned To',
+            'Assigned By',
+            'Assigned Date',
+            'Expected Return Date',
+            'State',
+            'Days Since Assigned',
+          ],
+        },
+        {
+          name: 'Returns and condition on hand-back',
+          code: 'RPT-2026-004',
+          description: 'What came back, from whom, and in what condition.',
+          source: 'Return History',
+          filters: {},
+          fields: [
+            'Asset Tag',
+            'Asset Name',
+            'Assigned To',
+            'Returned By',
+            'Assigned Date',
+            'Returned Date',
+            'Duration (Days)',
+            'Return Condition',
+          ],
+        },
+        {
+          name: 'Repair spend by vendor',
+          code: 'RPT-2026-005',
+          description:
+            'Completed repairs with estimate against actual, for vendor reviews.',
+          source: 'Maintenance Records',
+          filters: { status: 'COMPLETED' },
+          fields: [
+            'Asset Tag',
+            'Asset Name',
+            'Vendor Name',
+            'RMA Number',
+            'Reported Issue',
+            'Resolution Notes',
+            'Estimated Cost',
+            'Actual Cost',
+            'Cost Variance',
+            'Completion Date',
+          ],
+        },
+        {
+          name: 'Open maintenance queue',
+          code: 'RPT-2026-006',
+          description: 'Everything still with a vendor or awaiting triage.',
+          source: 'Maintenance Records',
+          filters: { status: 'ACTIVE' },
+          fields: [
+            'Ticket ID',
+            'Asset Tag',
+            'Asset Name',
+            'Ticket Type',
+            'Vendor Name',
+            'Reported Issue',
+            'Estimated Cost',
+            'Estimated Return Date',
+            'Dispatched By',
+          ],
+        },
+        {
+          name: 'Disposals and salvage recovered',
+          code: 'RPT-2026-007',
+          description: 'Completed write-offs with the value recovered on each.',
+          source: 'Disposal Records',
+          filters: {},
+          fields: [
+            'Disposal ID',
+            'Asset Tag',
+            'Asset Name',
+            'Requested By',
+            'Approved By',
+            'Status',
+            'Reason',
+            'Disposal Method',
+            'Salvage Value',
+          ],
+        },
+        {
+          name: 'Depreciation schedule',
+          code: 'RPT-2026-008',
+          description:
+            'Book value and accumulated depreciation across the depreciable fleet.',
+          source: 'Depreciation Ledger',
+          filters: {},
+          fields: [
+            'Asset Tag',
+            'Asset Name',
+            'Category',
+            'Purchase Cost',
+            'Useful Life (Months)',
+            'Salvage Value',
+            'Age (Months)',
+            'Monthly Depreciation',
+            'Accumulated Depreciation',
+            'Current Book Value',
+            'Depreciation %',
+          ],
+        },
+        {
+          name: 'Software licence renewals',
+          code: 'RPT-2026-009',
+          description: 'Seat usage and expiry dates for every active licence.',
+          source: 'Software Licenses',
+          filters: {},
+          fields: [
+            'License ID',
+            'Software Name',
+            'Publisher',
+            'License Key',
+            'License Type',
+            'Total Seats',
+            'Used Seats',
+            'Available Seats',
+            'Utilization %',
+            'Start Date',
+            'Expiry Date',
+            'Days Until Expiry',
+            'Status',
+          ],
+        },
+        {
+          name: 'Purchase history',
+          code: 'RPT-2026-010',
+          description: 'Acquisitions with vendor, tax and warranty terms.',
+          source: 'Purchase Records',
+          filters: {},
+          fields: [
+            'Purchase ID',
+            'Asset Tag',
+            'Asset Name',
+            'Vendor',
+            'Purchase Date',
+            'Base Price',
+            'Tax',
+            'Shipping Cost',
+            'Total Cost',
+            'Currency',
+            'Warranty Expiry',
+            'Warranty Remaining (Days)',
+          ],
+        },
+        {
+          name: 'Access and change audit',
+          code: 'RPT-2026-011',
+          description: 'System audit trail for compliance review.',
+          source: 'Audit Logs',
+          filters: {},
+          fields: [
+            'Log ID',
+            'Timestamp',
+            'User',
+            'Action',
+            'Entity Type',
+            'Entity ID',
+            'IP Address',
+            'Details',
+          ],
+        },
+      ];
+
+      for (const t of TEMPLATES) {
+        if (!t.fields.length)
+          throw new Error(`no fields listed for ${t.source}`);
+        await tx`
+          INSERT INTO report_templates (name, report_code, description, is_active, data_source, filters, fields, sort_direction, created_by_id)
+          VALUES (
+            ${t.name}, ${t.code}, ${t.description}, true, ${t.source},
+            ${sql.json(t.filters)}, ${sql.json(t.fields)}, 'asc', ${adminId}
+          )`;
+      }
+      summary.push(`report templates: ${TEMPLATES.length}`);
+
+      // ── 14. Integrations, devices and delivery logs ─────────────────────
       // These tables were left empty by the first pass, which reads as an
       // unfinished system on screen rather than a quiet one.
       const DEVICES: Array<[string, string, string]> = [

--- a/src/lib/data/asset-registry-repo.ts
+++ b/src/lib/data/asset-registry-repo.ts
@@ -28,7 +28,7 @@ import {
   users,
 } from '@/db/schema';
 import {
-  SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT,
+  SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT,
   isSoftwareLicenseNearCapacity,
 } from '@/lib/software-license-status';
 
@@ -240,7 +240,7 @@ export async function getAssetsByPillar(
               softwareLicenses.totalSeats,
               sql`coalesce(${assignedSeatsSubquery.count}, 0)`
             ),
-            sql`coalesce(${assignedSeatsSubquery.count}, 0) * 100 >= ${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT}`
+            sql`coalesce(${assignedSeatsSubquery.count}, 0) > 0 AND (${softwareLicenses.totalSeats} - coalesce(${assignedSeatsSubquery.count}, 0)) <= GREATEST(1, CEIL(${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT}::numeric / 100))`
           )
         )
       );
@@ -254,7 +254,7 @@ export async function getAssetsByPillar(
           softwareLicenses.totalSeats,
           sql`coalesce(${assignedSeatsSubquery.count}, 0)`
         ),
-        sql`coalesce(${assignedSeatsSubquery.count}, 0) * 100 < ${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT}`
+        sql`(coalesce(${assignedSeatsSubquery.count}, 0) = 0 OR (${softwareLicenses.totalSeats} - coalesce(${assignedSeatsSubquery.count}, 0)) > GREATEST(1, CEIL(${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT}::numeric / 100)))`
       );
     }
   }
@@ -444,7 +444,7 @@ export async function getAllAssetsUnified(
               softwareLicenses.totalSeats,
               sql`coalesce(${assignedSeatsSubquery.count}, 0)`
             ),
-            sql`coalesce(${assignedSeatsSubquery.count}, 0) * 100 >= ${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT}`
+            sql`coalesce(${assignedSeatsSubquery.count}, 0) > 0 AND (${softwareLicenses.totalSeats} - coalesce(${assignedSeatsSubquery.count}, 0)) <= GREATEST(1, CEIL(${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT}::numeric / 100))`
           )
         )
       );
@@ -458,7 +458,7 @@ export async function getAllAssetsUnified(
           softwareLicenses.totalSeats,
           sql`coalesce(${assignedSeatsSubquery.count}, 0)`
         ),
-        sql`coalesce(${assignedSeatsSubquery.count}, 0) * 100 < ${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT}`
+        sql`(coalesce(${assignedSeatsSubquery.count}, 0) = 0 OR (${softwareLicenses.totalSeats} - coalesce(${assignedSeatsSubquery.count}, 0)) > GREATEST(1, CEIL(${softwareLicenses.totalSeats} * ${SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT}::numeric / 100)))`
       );
     }
   }

--- a/src/lib/software-license-status.test.ts
+++ b/src/lib/software-license-status.test.ts
@@ -1,17 +1,52 @@
 import { describe, expect, it } from 'vitest';
-import { isSoftwareLicenseNearCapacity } from './software-license-status';
+import {
+  isSoftwareLicenseNearCapacity,
+  softwareLicenseWarningThreshold,
+} from './software-license-status';
+
+describe('softwareLicenseWarningThreshold', () => {
+  it('is 10% of the seats, rounded up', () => {
+    expect(softwareLicenseWarningThreshold(40)).toBe(4);
+    expect(softwareLicenseWarningThreshold(45)).toBe(5);
+    expect(softwareLicenseWarningThreshold(10)).toBe(1);
+  });
+
+  it('never drops below one seat', () => {
+    // 10% of 4 is 0.4. Without the floor a small licence could only ever be
+    // available or full, with no warning band between them.
+    expect(softwareLicenseWarningThreshold(4)).toBe(1);
+    expect(softwareLicenseWarningThreshold(1)).toBe(1);
+  });
+
+  it('is zero for a licence with no seats', () => {
+    expect(softwareLicenseWarningThreshold(0)).toBe(0);
+  });
+});
 
 describe('isSoftwareLicenseNearCapacity', () => {
   it('does not warn when no seats are allocated', () => {
     expect(isSoftwareLicenseNearCapacity(1, 1)).toBe(false);
+    expect(isSoftwareLicenseNearCapacity(10, 10)).toBe(false);
   });
 
-  it('warns at 80% utilization before the license is full', () => {
-    expect(isSoftwareLicenseNearCapacity(10, 2)).toBe(true);
+  it('warns only once 10% or less of the seats remain', () => {
+    // A ten-seat licence keeps its status until the last seat is left. Under
+    // the old 80%-utilisation rule it warned with two of ten still free.
+    expect(isSoftwareLicenseNearCapacity(10, 3)).toBe(false);
+    expect(isSoftwareLicenseNearCapacity(10, 2)).toBe(false);
+    expect(isSoftwareLicenseNearCapacity(10, 1)).toBe(true);
   });
 
-  it('does not warn for low utilization even when the absolute available count is small', () => {
+  it('scales the band with the licence size', () => {
+    expect(isSoftwareLicenseNearCapacity(40, 5)).toBe(false);
+    expect(isSoftwareLicenseNearCapacity(40, 4)).toBe(true);
+    expect(isSoftwareLicenseNearCapacity(100, 11)).toBe(false);
+    expect(isSoftwareLicenseNearCapacity(100, 10)).toBe(true);
+  });
+
+  it('gives small licences a one-seat warning band', () => {
     expect(isSoftwareLicenseNearCapacity(3, 2)).toBe(false);
+    expect(isSoftwareLicenseNearCapacity(3, 1)).toBe(true);
   });
 
   it('leaves full licenses for the full status instead of warning', () => {

--- a/src/lib/software-license-status.ts
+++ b/src/lib/software-license-status.ts
@@ -1,21 +1,45 @@
 import { differenceInDays } from 'date-fns';
 
-export const SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT = 80;
+/**
+ * A licence warns once this share or less of its seats is still free.
+ *
+ * Expressed as seats remaining rather than seats used so the band means the
+ * same thing at every licence size: 10% left is 4 seats on a 40-seat licence
+ * and 1 on a 10-seat one. The previous rule warned at 20% remaining, which on
+ * a small licence fired while a fifth of it was still unused.
+ */
+export const SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT = 10;
+
+/**
+ * Seats that must remain before a licence stops warning.
+ *
+ * Rounded up and floored at one, so every licence gets at least a one-seat
+ * warning band. Without the floor a 4-seat licence would want 0.4 seats left
+ * and could only ever be "available" or "full", skipping the warning entirely.
+ */
+export function softwareLicenseWarningThreshold(totalSeats: number) {
+  if (totalSeats <= 0) return 0;
+  return Math.max(
+    1,
+    Math.ceil((totalSeats * SOFTWARE_LICENSE_WARNING_REMAINING_PERCENT) / 100)
+  );
+}
 
 export function isSoftwareLicenseNearCapacity(
   totalSeats: number,
   availableSeats: number
 ) {
   if (totalSeats <= 0 || availableSeats <= 0) {
+    // No seats left is "full", which is a different state.
     return false;
   }
 
-  const assignedSeats = Math.max(0, totalSeats - availableSeats);
-  return (
-    assignedSeats < totalSeats &&
-    assignedSeats * 100 >=
-      totalSeats * SOFTWARE_LICENSE_WARNING_UTILIZATION_PERCENT
-  );
+  // Nothing handed out yet is never "near capacity", even on a one-seat
+  // licence where the threshold and the seat count are both 1.
+  const assignedSeats = totalSeats - availableSeats;
+  if (assignedSeats <= 0) return false;
+
+  return availableSeats <= softwareLicenseWarningThreshold(totalSeats);
 }
 
 /**

--- a/src/types/standard-reports.seed-templates.test.ts
+++ b/src/types/standard-reports.seed-templates.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { REPORT_FIELD_OPTIONS_BY_SOURCE } from '@/types/standard-reports';
+
+/**
+ * The demo seed lists report-template fields by name.
+ *
+ * It cannot import this map: the seed is a `.mts` run directly by node, which
+ * needs a `.ts` extension on the import, and `tsc` rejects that without
+ * `allowImportingTsExtensions`. So the names are duplicated there, and this
+ * test is what stops the copy drifting -- a renamed field would otherwise
+ * leave a saved template quietly producing an empty column.
+ */
+const SEED = readFileSync(
+  join(process.cwd(), 'scripts', 'seed-demo-data.mts'),
+  'utf8'
+);
+
+/** Pulls `source` and `fields` out of each template literal in the seed. */
+function parseSeedTemplates() {
+  const templates: Array<{ source: string; fields: string[] }> = [];
+  const blocks = SEED.matchAll(
+    /source: '([^']+)',\s*\n\s*filters: \{[^}]*\},\s*\n\s*fields: \[([\s\S]*?)\],/g
+  );
+  for (const [, source, raw] of blocks) {
+    const fields = [...raw.matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    templates.push({ source, fields });
+  }
+  return templates;
+}
+
+describe('demo seed report templates', () => {
+  const templates = parseSeedTemplates();
+
+  it('parses every template the seed declares', () => {
+    // Counted independently off the report codes: a parser that silently
+    // matched only some templates would leave the rest unguarded while this
+    // suite still passed.
+    const declared = [...SEED.matchAll(/code: 'RPT-[0-9-]+'/g)].length;
+    expect(declared).toBeGreaterThanOrEqual(10);
+    expect(templates.length).toBe(declared);
+  });
+
+  it('only names data sources the report builder knows', () => {
+    const known = Object.keys(REPORT_FIELD_OPTIONS_BY_SOURCE);
+    for (const t of templates) expect(known).toContain(t.source);
+  });
+
+  it('only names fields the builder offers for that source', () => {
+    for (const t of templates) {
+      const allowed = REPORT_FIELD_OPTIONS_BY_SOURCE[t.source];
+      for (const field of t.fields) {
+        expect(allowed, `"${field}" is not a field of ${t.source}`).toContain(
+          field
+        );
+      }
+    }
+  });
+
+  it('gives every template at least one field', () => {
+    for (const t of templates) expect(t.fields.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Seat warning

One correction to the premise first: there was no `< 10 available seats` rule anywhere. The only seat rule was already proportional, at **80% utilised (20% remaining)** — which is what made a 10-seat licence warn with 2 seats still free. Changed to **10% remaining** as you asked.

Reworded from seats-used to seats-remaining so the band means the same thing at any size:

| Seats | Warned at (before) | Warns at (now) |
|---|---|---|
| 10 | 2 free | 1 free |
| 40 | 8 free | 4 free |
| 45 | 9 free | 5 free |

Two edge cases the change surfaced:

- **Floor of one seat.** 10% of a 4-seat licence is 0.4, so without a floor a small licence could only ever be *available* or *full*, skipping the warning entirely.
- **Nothing allocated is never near capacity.** On a 1-seat licence the threshold and the seat count are both 1, so an untouched licence would have warned. Guarded in both the TS helper and the SQL filter.

The registry grid filters this in SQL while the status badge computes it in TS — the same split that let the depreciation rule drift. I verified them against all 11 live licences: **SQL and TS agree on every row**.

On the live data `BKP-001` (10 seats, 2 free, 80% used) now reads *available* instead of *warning*, which is the case you reported.

## Report templates

Eleven saved templates covering hardware register, furniture by location, assets on loan, returns and condition, repair spend by vendor, open maintenance queue, disposals and salvage, depreciation schedule, licence renewals, purchase history and the audit trail.

Field names and filter keys are the ones the fetchers actually read, so each template runs rather than just looking plausible. The seed is a `.mts` run directly by node and can't import `REPORT_FIELD_OPTIONS_BY_SOURCE` (node needs a `.ts` extension, tsc rejects it), so the names are duplicated — and `standard-reports.seed-templates.test.ts` parses the seed and asserts every source and field is one the builder offers. It also counts templates independently off the report codes, so a parser that silently matched only some of them can't pass.

tsc, lint, 1319 tests and build all green.
